### PR TITLE
fix(wihs): rm whitespace in resid enum

### DIFF
--- a/gdcdictionary/schemas/summary_socio_demographic.yaml
+++ b/gdcdictionary/schemas/summary_socio_demographic.yaml
@@ -67,7 +67,7 @@ properties:
     enum:
       - "Own house/apartment"
       - "Parent's house"
-      - "Someone else's house/ apartment"
+      - "Someone else's house/apartment"
       - "Rooming/boarding/halfway house"
       - "Shelter/welfare hotel"
       - "Street"


### PR DESCRIPTION
Removed a wrong whitespace in one option for the residence id in socio demographic node.