### PR TITLE
Feat/revert hiv

### DIFF
--- a/gdcdictionary/schemas/hiv_history.yaml
+++ b/gdcdictionary/schemas/hiv_history.yaml
@@ -55,7 +55,9 @@ properties:
       Summarized HIV sero-status
     enum:
       - Negative
-      - Positive
+      - Prevalent
+      - Converter
+      - Converter identified at death
 
   lnegdate:
     description: >

--- a/gdcdictionary/schemas/laboratory_result.yaml
+++ b/gdcdictionary/schemas/laboratory_result.yaml
@@ -180,7 +180,7 @@ properties:
       CD3/CD8 Q IV T Lymphocytes
     type: number
 
-  cd4n:
+  leu3n:
     description: >
       Number of CD4 positive cells (helpers)/ul
     type: number
@@ -421,7 +421,7 @@ properties:
       If urine protein < 4, ratio usually not submitted by testing lab
     type: number
 
-  VLOAD:
+  viral_load:
     description: >
       Standardized viral load (copies/ml)
     type: number

--- a/gdcdictionary/schemas/project.yaml
+++ b/gdcdictionary/schemas/project.yaml
@@ -24,6 +24,7 @@ required:
   - code
   - name
   - programs
+  - dbgap_accession_number
 
 uniqueKeys:
   - [ id ]

--- a/gdcdictionary/schemas/project.yaml
+++ b/gdcdictionary/schemas/project.yaml
@@ -24,8 +24,7 @@ required:
   - code
   - name
   - programs
-  - dbgap_accession_number
-  
+
 uniqueKeys:
   - [ id ]
   - [ code ]

--- a/gdcdictionary/schemas/summary_drug_use.yaml
+++ b/gdcdictionary/schemas/summary_drug_use.yaml
@@ -684,7 +684,6 @@ properties:
       - "HAART"
       - "HAART (HU/ddI defined)"
       - "unknown regimen"
-      - "Potent ART"
       - "Missing"
 
   thrpyv:

--- a/gdcdictionary/schemas/summary_lab_result.yaml
+++ b/gdcdictionary/schemas/summary_lab_result.yaml
@@ -170,12 +170,12 @@ properties:
          term_id: C129775
          term_version: 18.10e (Release date:2018-10-29)
 
-  cd4n:
+  leu3n:
     description: >
       # of CD4 positive cells (helpers, cells per mm^3)
     type: integer
     termDef:
-       - term: cd4n
+       - term: leu3n
          source: NCI Thesaurus
          term_id: C55931
          term_version: 18.10e (Release date:2018-10-29)
@@ -311,12 +311,12 @@ properties:
         term_id: C85533
         term_version: 18.12e (Release date:2018-12-31)
 
-  VLOAD:
+  viral_load:
     description: >
       Standardized viral load (copies/ml)
     type: number
     termDef:
-       - term: VLOAD
+       - term: viral_load
          source: NCI Thesaurus
          term_id: C51952
          term_version: 18.10e (Release date:2018-10-29)


### PR DESCRIPTION
Reverts commits made in merge #87 - this does not revert the merge itself, but each of the two commits which were made in that merge. The inverse changes of those commits were made, effectively "undo-ing" those changes - but this is a forward step, not a backward step, in the history. Allows for a step up in versioning without having to wait for the data migration which has to happen before the changes from merge #87 can be deployed to production.