### PR TITLE
chore(qa): Remove Jenkinsfile as branch-DD is not being tested

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,0 @@
-#!groovy
-
-@Library('cdis-jenkins-lib@master') _
-
-testPipeline {
-}


### PR DESCRIPTION
Removing Jenkinsfile as, currently, the pipeline is not able to test the DD without utilizing a `portal/gitops.json` and `etlMapping.yaml`.

We need to rethink this approach.